### PR TITLE
New message type added for pair programming

### DIFF
--- a/node.server/messages-core.js
+++ b/node.server/messages-core.js
@@ -62,6 +62,8 @@ MessageCore.prototype.initialize = function(socket, sockets) {
 	this.configureBroadcast(socket, 'liveResourceChanged');
 	this.configureBroadcast(socket, 'liveMetadataChanged');
 
+	this.configureBroadcast(socket, 'liveCursorOffsetChanged');
+
 	this.configureRequest(socket, 'contentassistrequest');
 	this.configureResponse(socket, sockets, 'contentassistresponse');
 

--- a/node.server/rabbit-connector.js
+++ b/node.server/rabbit-connector.js
@@ -344,6 +344,8 @@ RabbitConnector.prototype.configure = function() {
 	this.configureBroadcast('liveResourceChanged');
 	this.configureBroadcast('liveMetadataChanged');
 
+	this.configureBroadcast('liveCursorOffsetChanged');
+
 	this.configureRequest('contentassistrequest');
 	this.configureResponse('contentassistresponse');
 


### PR DESCRIPTION
I have been developing a plugin for Eclipse che which supports pair programming with displaying everyone's cursors on the editor. Since there was no braodcast type for cursor position changes I have added a new one.
https://github.com/rnavagamuwa/che-plugin-flux-live-edit
Signed-off-by: rnavagamuwa <randikanavagamuwa@gmail.com>